### PR TITLE
TST: clean up pysat install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,13 @@ before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
-  - pip install matplotlib
-  - pip install pysatCDF >/dev/null
-  - pip install apexpy
-
-before_install:
-  - pip install pytest-cov
-  - pip install coveralls
-  - pip install future
   # Install version specific packages for 2.7 and 3.5
   - pip install 'pandas<0.25'
   - pip install xarray
   - pip install matplotlib
   - pip install apexpy
   - pip install numpy
-  
+  - pip install pysatCDF >/dev/null
   - pip install 'pysat>=2.1.0'
   # set up data directory
   - mkdir /home/travis/build/pysatData

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   - pip install 'pysat>=2.1.0'
   # set up data directory
   - mkdir /home/travis/build/pysatData
+  - python -c 'import pysat; pysat.utils.set_data_dir("/home/travis/build/pysatData")'
 
 install:
   # install pysatMagVect

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,13 @@ before_install:
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
   - python setup.py install >/dev/null
-  - cd ..
   # set up data directory
   - mkdir /home/travis/build/pysatData
   - python -c 'import pysat; pysat.utils.set_data_dir("/home/travis/build/pysatData")'
 
 install:
   # install pysatMagVect
-  - cd ./pysatMagVect
+  - cd ../pysatMagVect
   - python setup.py develop
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ before_install:
   - pip install apexpy
   - pip install numpy
   - pip install pysatCDF >/dev/null
-  - pip install 'pysat>=2.1.0'
+  - git clone https://github.com/pysat/pysat.git >/dev/null
+  - cd ./pysat
+  - python setup.py install >/dev/null
+  - cd ..
   # set up data directory
   - mkdir /home/travis/build/pysatData
   - python -c 'import pysat; pysat.utils.set_data_dir("/home/travis/build/pysatData")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 install:
   # install pysatMagVect
-  - cd ../pysatMagVect
+  - cd ./pysatMagVect
   - python setup.py develop
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - pip install apexpy
   - pip install numpy
   - pip install pysatCDF >/dev/null
+  - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
   - python setup.py install >/dev/null
@@ -32,7 +33,7 @@ before_install:
 
 install:
   # install pysatMagVect
-  - cd ../pysatMagVect
+  - cd ./pysatMagVect
   - python setup.py develop
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,20 @@ before_install:
   - pip install pysatCDF >/dev/null
   - pip install apexpy
 
-  # Prepare modified pysat install
+before_install:
+  - pip install pytest-cov
+  - pip install coveralls
+  - pip install future
+  # Install version specific packages for 2.7 and 3.5
+  - pip install 'pandas<0.25'
+  - pip install xarray
+  - pip install matplotlib
+  - pip install apexpy
   - pip install numpy
-  - cd ..
-  - echo 'cloning pysat'
-  - git clone https://github.com/pysat/pysat.git >/dev/null
-  - echo 'installing pysat'
-  - cd ./pysat
-  - git checkout develop
+  
+  - pip install 'pysat>=2.1.0'
   # set up data directory
   - mkdir /home/travis/build/pysatData
-  # install pysat
-  - python setup.py install >/dev/null
 
 install:
   # install pysatMagVect

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
   - python setup.py install >/dev/null
+  - cd ..
   # set up data directory
   - mkdir /home/travis/build/pysatData
   - python -c 'import pysat; pysat.utils.set_data_dir("/home/travis/build/pysatData")'


### PR DESCRIPTION
# Description

Pysat 2.1.0 is now available via pip.  There is no longer a need for the custom pysat install, so the pysat family of codes is being upgraded to a "standard" installation through pip.  This will allow the `no_sgp4` branch of pysat to be deleted.

## Type of change

- Test environment update

# How Has This Been Tested?

Updates to Travis-CI environment, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
